### PR TITLE
Move mouse in W3C and non-W3C mode before clicking

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -843,14 +843,10 @@ JS;
 
     private function clickOnElement(Element $element): void
     {
-        if ($this->isW3C()) {
-            $element->click();
-        }
-        else {
-            // Move the mouse to the element as Selenium does not allow clicking on an element which is outside the viewport
-            $this->getWebDriverSession()->moveto(array('element' => $element->getID()));
-            $element->click();
-        }
+        // Move the mouse to the element as Selenium does not allow clicking on an element which is outside the viewport
+        $this->doMouseOver($element);
+
+        $element->click();
     }
 
     public function doubleClick(string $xpath)
@@ -939,6 +935,11 @@ JS;
 
     public function mouseOver(string $xpath)
     {
+        $this->doMouseOver($this->findElement($xpath));
+    }
+
+    private function doMouseOver(Element $element)
+    {
         if ($this->isW3C()) {
             $actions = array(
                 'actions' => [
@@ -947,7 +948,7 @@ JS;
                         'id' => 'mouse1',
                         'parameters' => ['pointerType' => 'mouse'],
                         'actions' => [
-                            ['type' => 'pointerMove', 'duration' => 0, 'origin' => [Element::WEB_ELEMENT_ID => $this->findElement($xpath)->getID()], 'x' => 0, 'y' => 0],
+                            ['type' => 'pointerMove', 'duration' => 0, 'origin' => [Element::WEB_ELEMENT_ID => $element->getID()], 'x' => 0, 'y' => 0],
                         ],
                     ],
                 ],
@@ -957,7 +958,7 @@ JS;
         }
         else {
             $this->getWebDriverSession()->moveto(array(
-                'element' => $this->findElement($xpath)->getID()
+                'element' => $element->getID()
             ));
         }
     }

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -938,7 +938,7 @@ JS;
         $this->doMouseOver($this->findElement($xpath));
     }
 
-    private function doMouseOver(Element $element)
+    private function doMouseOver(Element $element): void
     {
         if ($this->isW3C()) {
             $actions = array(


### PR DESCRIPTION
This makes the two modes work the same which is good when trying to move from one to the other.