### PR TITLE
Scroll into view before moving pointer to make Firefox behave the same as Chrome

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,11 @@ jobs:
         # 4.1.2-20220227 - last known working version of 4 where the modifications to this package weren't needed
         selenium:
           - image: 'selenium/standalone-firefox:4.1.2'
+            browser: firefox
           - image: 'selenium/standalone-firefox:latest'
+            browser: firefox
           - image: 'selenium/standalone-chrome:latest'
-            env: WEB_FIXTURES_BROWSER=chrome
+            browser: chrome
 
       fail-fast: false
 
@@ -93,6 +95,7 @@ jobs:
           while ! nc -z localhost 8002 </dev/null; do echo Waiting for PHP server to start...; sleep 1; done
 
       - name: Run tests
+        env: WEB_FIXTURES_BROWSER=${{matrix.selenium.browser}}
         run: |
           ./vendor/bin/phpunit -v --coverage-clover=coverage.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,8 @@ jobs:
           while ! nc -z localhost 8002 </dev/null; do echo Waiting for PHP server to start...; sleep 1; done
 
       - name: Run tests
-        env: WEB_FIXTURES_BROWSER=${{matrix.selenium.browser}}
+        env:
+          WEB_FIXTURES_BROWSER: ${{matrix.selenium.browser}}
         run: |
           ./vendor/bin/phpunit -v --coverage-clover=coverage.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,12 @@ jobs:
       matrix:
         php: [ '8.1', '8.2', '8.3' ]
         # 4.1.2-20220227 - last known working version of 4 where the modifications to this package weren't needed
-        selenium: ['4.1.2', 'latest']
+        selenium:
+          - image: 'selenium/standalone-firefox:4.1.2'
+          - image: 'selenium/standalone-firefox:latest'
+          - image: 'selenium/standalone-chrome:latest'
+            env: WEB_FIXTURES_BROWSER=chrome
+
       fail-fast: false
 
     steps:
@@ -80,7 +85,7 @@ jobs:
 
       - name: Start Selenium
         run: |
-          docker run --net host --name selenium --volume /dev/shm:/dev/shm --volume $GITHUB_WORKSPACE:$GITHUB_WORKSPACE -e SE_NODE_OVERRIDE_MAX_SESSIONS=true -e SE_NODE_MAX_SESSIONS=5 --shm-size 2g selenium/standalone-firefox:${{ matrix.selenium }} &> ./logs/selenium.log &
+          docker run --net host --name selenium --volume /dev/shm:/dev/shm --volume $GITHUB_WORKSPACE:$GITHUB_WORKSPACE -e SE_NODE_OVERRIDE_MAX_SESSIONS=true -e SE_NODE_MAX_SESSIONS=5 --shm-size 2g ${{ matrix.selenium.image }} &> ./logs/selenium.log &
 
       - name: Wait for browser & PHP to start
         run: |

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -950,7 +950,7 @@ JS;
         $this->doMouseOver($this->findElement($xpath));
     }
 
-    private function scrollElementIntoView(Element $element) {
+    private function scrollElementIntoView(Element $element): void {
         $script = <<<JS
             var e = arguments[0];
             e.scrollIntoView({ behavior: 'instant', block: 'end', inline: 'nearest' });

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -950,9 +950,23 @@ JS;
         $this->doMouseOver($this->findElement($xpath));
     }
 
+    private function scrollElementIntoView(Element $element) {
+        $script = <<<JS
+            var e = arguments[0];
+            e.scrollIntoView({ behavior: 'instant', block: 'end', inline: 'nearest' });
+            var rect = e.getBoundingClientRect();
+            return {'x': rect.left, 'y': rect.top};
+        JS;
+
+        $this->executeJsOnElement($element, $script);
+    }
+
     private function doMouseOver(Element $element): void
     {
         if ($this->isW3C()) {
+            // Firefox needs the element in view in order to move the pointer to
+            // it.
+            $this->scrollElementIntoView($element);
             $actions = array(
                 'actions' => [
                     [

--- a/tests/Custom/DesiredCapabilitiesTest.php
+++ b/tests/Custom/DesiredCapabilitiesTest.php
@@ -7,6 +7,14 @@ use Behat\Mink\Tests\Driver\TestCase;
 
 class DesiredCapabilitiesTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $browser = getenv('WEB_FIXTURES_BROWSER') ?: 'firefox';
+        if ($browser !== 'firefox') {
+            $this->markTestSkipped('This test only works with Firefox');
+        }
+    }
+
     public function testGetDesiredCapabilities()
     {
         $caps = array(

--- a/tests/Custom/LargePageClickTest.php
+++ b/tests/Custom/LargePageClickTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Behat\Mink\Tests\Driver\Custom;
+
+use Behat\Mink\Tests\Driver\TestCase;
+
+class LargePageClickTest extends TestCase
+{
+    public function testLargePageClick(): void
+    {
+        $this->getSession()->visit($this->pathTo('/multi_input_form.html'));
+
+        // Add a large amount of br tags so that the button is not in view.
+        $large_page = str_repeat('<br />', 2000);
+        $script = <<<JS
+            const p = document.createElement("div");
+            p.innerHTML = "$large_page";
+            document.body.insertBefore(p, document.body.firstChild);
+        JS;
+        $this->getSession()->executeScript($script);
+
+        $page = $this->getSession()->getPage();
+        $page->pressButton('Register');
+        $this->assertStringContainsString('no file', $page->getContent());
+    }
+}


### PR DESCRIPTION
Tried to get Drupal core tests running on firefox see https://git.drupalcode.org/project/drupal/-/jobs/2206793 … some are passing but a load fail due to https://stackoverflow.com/questions/44777053/selenium-movetargetoutofboundsexception-with-firefox 

The webdriver-classic-driver does https://github.com/minkphp/webdriver-classic-driver/blob/73ad0b6ce21cf697c15d8131c32656cad8b8b0ec/src/WebdriverClassicDriver.php#L1007