### PR TITLE
Scroll element to center of viewport to avoid bottom overlay interference

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -953,7 +953,7 @@ JS;
     private function scrollElementIntoView(Element $element): void {
         $script = <<<JS
             var e = arguments[0];
-            e.scrollIntoView({ behavior: 'instant', block: 'end', inline: 'nearest' });
+            e.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'nearest' });
             var rect = e.getBoundingClientRect();
             return {'x': rect.left, 'y': rect.top};
         JS;

--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -1188,7 +1188,7 @@ JS;
     {
         // short-circuit when we already have the right button of the group to avoid XPath queries
         if ($element->attribute('value') === $value) {
-            $element->click();
+            $this->clickOnElement($element);
 
             return;
         }
@@ -1230,7 +1230,7 @@ XPATH;
             throw new DriverException($message, 0, $e);
         }
 
-        $input->click();
+        $this->clickOnElement($input);
     }
 
     /**
@@ -1242,6 +1242,7 @@ XPATH;
         // The value of an option is the normalized version of its text when it has no value attribute
         $optionQuery = sprintf('.//option[@value = %s or (not(@value) and normalize-space(.) = %s)]', $escapedValue, $escapedValue);
         $option = $element->element('xpath', $optionQuery);
+        $this->doMouseOver($element);
 
         if ($multiple || !$element->attribute('multiple')) {
             if (!$option->selected()) {

--- a/tests/Custom/LargePageClickTest.php
+++ b/tests/Custom/LargePageClickTest.php
@@ -8,14 +8,48 @@ class LargePageClickTest extends TestCase
 {
     public function testLargePageClick(): void
     {
-        $this->getSession()->visit($this->pathTo('/multi_input_form.html'));
+        $this->getSession()->visit($this->pathTo('/advanced_form.html'));
+        // @todo Why is size attribute causing ElementClickIntercepted errors?
+        $this->getSession()->executeScript('document.querySelector("input[name=\'first_name\']").setAttribute("size", 200);');
 
-        // Add a large amount of br tags so that the button is not in view.
+        // Add a large amount of br tags so that form elements are not in view.
         $this->makePageLong();
 
         $page = $this->getSession()->getPage();
+
+        // Test select focus.
+        $this->scrollToTop();
+        $page->selectFieldOption('select_number', 'thirty');
+
+        // Test radio button focus.
+        $this->scrollToTop();
+        $page->selectFieldOption('sex', 'm');
+
+        // Test checkboxes focus.
+        $this->scrollToTop();
+        $page->uncheckField('mail_list');
+        $this->scrollToTop();
+        $page->checkField('agreement');
+
+        // Test button focus and submit.
+        $this->scrollToTop();
         $page->pressButton('Register');
-        $this->assertStringContainsString('no file', $page->getContent());
+
+        $expected = <<<EOF
+array(
+  agreement = `on`,
+  email = `your@email.com`,
+  first_name = `Firstname`,
+  last_name = `Lastname`,
+  notes = `original notes`,
+  select_number = `30`,
+  sex = `m`,
+  submit = `Register`,
+)
+no file
+EOF;
+
+        $this->assertStringContainsString($expected, $page->getContent());
     }
 
     public function testDragDrop(): void
@@ -45,6 +79,13 @@ class LargePageClickTest extends TestCase
             document.body.insertBefore(p, document.body.firstChild);
         JS;
         $this->getSession()->executeScript($script);
+    }
+
+    /**
+     * Scrolls to the top of the page.
+     */
+    private function scrollToTop(): void {
+        $this->getSession()->executeScript('window.scrollTo(0, 0);');
     }
 
 }


### PR DESCRIPTION
Following https://github.com/Lullabot/MinkSelenium2Driver/pull/10 and https://github.com/Lullabot/MinkSelenium2Driver/pull/13 logic, I noticed radios and select elements also require a scrollIntoView which are currently missing. Without this, we get MoveTargetOutOfBounds exception when attempting to click on select/radios which are out of the viewport.