### PR TITLE
Fixed scrolling an element into view only if it is not within a view.

### DIFF
--- a/src/Selenium2Driver.php
+++ b/src/Selenium2Driver.php
@@ -953,8 +953,19 @@ JS;
     private function scrollElementIntoView(Element $element): void {
         $script = <<<JS
             var e = arguments[0];
-            e.scrollIntoView({ behavior: 'instant', block: 'end', inline: 'nearest' });
             var rect = e.getBoundingClientRect();
+            var inView = (
+                rect.top >= 0 &&
+                rect.left >= 0 &&
+                rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+                rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+            );
+
+            if (!inView) {
+                e.scrollIntoView({ behavior: 'instant', block: 'end', inline: 'nearest' });
+                rect = e.getBoundingClientRect();
+            }
+
             return {'x': rect.left, 'y': rect.top};
         JS;
 


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/Lullabot/MinkSelenium2Driver/pull/10: the scrolling an element into the view should only take place if the element is not already within the view.